### PR TITLE
removed call to parent::__call

### DIFF
--- a/src/Data/Repositories/Repository.php
+++ b/src/Data/Repositories/Repository.php
@@ -209,7 +209,5 @@ class Repository
 
             return call_user_func_array(array($this, 'findBy'), $arguments);
         }
-
-        parent::__call($method, $arguments);
     }
 }


### PR DESCRIPTION
This file has no parent, so the call to the parent::__call method is useless